### PR TITLE
feat: track demo generate click and standardize form start event

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+/** Simple sample component used for testing Tailwind */
 export default function App() {
   return (
     <div className="min-h-screen bg-background text-foreground p-6">

--- a/src/components/BetaSignupForm.tsx
+++ b/src/components/BetaSignupForm.tsx
@@ -2,12 +2,15 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { trackEvent } from '../lib/analytics';
 
+/** Props for the signup form component */
 type Props = { variant: "A" | "B"; selectedPlan?: 'starter' | 'business' | '' };
+/** Possible plan hints passed via query string */
 type PlanHint = 'starter' | 'business' | 'founder' | '';
+/** Plans the user can select */
 type Plan = 'starter' | 'business' | '';
 
-/** Helper: BRL formatting */
-function formatBRL(n: number) {
+/** Format a number as BRL currency */
+function formatBRL(n: number): string {
     try {
         return n.toLocaleString('pt-BR', {
             style: 'currency',
@@ -24,7 +27,7 @@ const PRICE_STARTER = 19.9;
 const PRICE_BUSINESS = 59.9;
 const FOUNDER_DISCOUNT = 0.3; // 30%
 
-/** Beta signup form */
+/** Beta signup form component */
 export default function BetaSignupForm({ variant, selectedPlan = '' }: Props) {
     // Read ?plan_hint= from URL (starter, business, founder)
     const location = useLocation()
@@ -64,30 +67,32 @@ export default function BetaSignupForm({ variant, selectedPlan = '' }: Props) {
       ? { main: PRICE_BUSINESS * (1 - FOUNDER_DISCOUNT), original: PRICE_BUSINESS }
       : { main: PRICE_BUSINESS, original: null as number | null};
 
-    // Netlify x-www-form-urlencoded encoding
-    function encode(data: Record<string, string>) {
+    /** Encode object to x-www-form-urlencoded for Netlify */
+    function encode(data: Record<string, string>): string {
         return Object.keys(data)
             .map((k) => encodeURIComponent(k) + "=" + encodeURIComponent(data[k]))
             .join("&")
     }
 
-    // Fire from_start once, on first focus
-    function handleFirstFocus() {
+    /** Track form_start once on first user focus */
+    function handleFirstFocus(): void {
         if(!started) {
             setStarted(true);
             startedAtRef.current = Date.now();
-            trackEvent('from_start', { variant });
+            trackEvent('form_start', { variant });
         }
     }
 
-    function handlePlanChange(next: Plan) {
+    /** Handle plan selection changes and track analytics */
+    function handlePlanChange(next: Plan): void {
         if (next != plan) {
             setPlan(next);
             if (next) trackEvent('plan-select-change', { variant, plan: next });
         }
     }
 
-    async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
+    /** Submit the form and send analytics events */
+    async function onSubmit(e: React.FormEvent<HTMLFormElement>): Promise<void> {
         e.preventDefault()
 
         // Anti-bot: require 3s since first interaction
@@ -128,7 +133,7 @@ export default function BetaSignupForm({ variant, selectedPlan = '' }: Props) {
             });
 
             // GA: DO NOT send the message text, only derived metrics
-            trackEvent('lead_submut', {
+            trackEvent('lead_submit', {
                 variant,
                 profile,
                 volume,

--- a/src/components/DemoPlayground.tsx
+++ b/src/components/DemoPlayground.tsx
@@ -3,6 +3,7 @@ import { trackEvent } from '../lib/analytics';
 
 type Props = { className?: string };
 
+/** Demo playground placeholder for Variant B */
 export default function DemoPlayground({ className = ''}: Props) {
     const ref = useRef<HTMLDivElement | null>(null);
     const firedRef = useRef(false);

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,6 +1,9 @@
-declare global { interface Window { dataLayer?: any[]; gtag?: (...args:any[]) => void } }
+declare global {
+  interface Window { dataLayer?: unknown[]; gtag?: (...args: unknown[]) => void }
+}
 
-export function initGA(id: string) {
+/** Initialize GA4 script and configuration */
+export function initGA(id: string): void {
     if (typeof window.gtag === 'function') return; // tag already initialized
     if (!id) {
         if (import.meta.env.PROD) console.warn("[GA4] VITE_GA4_ID missing in production build");
@@ -13,11 +16,12 @@ export function initGA(id: string) {
     document.head.appendChild(s);
 
     window.dataLayer = window.dataLayer || [];
-    window.gtag = (...args:any[]) => window.dataLayer!.push(args);
+    window.gtag = (...args: unknown[]) => window.dataLayer!.push(args);
     window.gtag('js', new Date());
-    window.gtag('config', id, { send_page_view:false, debug_mode: !import.meta.env.PROD });
+    window.gtag('config', id, { send_page_view: false, debug_mode: !import.meta.env.PROD });
 }
 
-export function trackEvent(name: string, params: Record<string, any> = {}) {
-    if (typeof window.gtag === 'function') window.gtag('event', name, params);
+/** Safely send an event to GA4 */
+export function trackEvent(name: string, params: Record<string, unknown> = {}): void {
+  if (typeof window.gtag === 'function') window.gtag('event', name, params);
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,1 +1,2 @@
+/** GA4 measurement ID sourced from Vite environment */
 export const GA_MEASUREMENT_ID = import.meta.env.VITE_GA4_ID as string;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,3 +1,4 @@
-export function cn(...classes: (string | undefined| false)[]) {
+/** Concatenate CSS class names, ignoring falsey values */
+export function cn(...classes: (string | undefined | false)[]): string {
     return classes.filter(Boolean).join(' ');
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,18 +1,20 @@
-import React from "react"
-import ReactDom from "react-dom/client"
-import { BrowserRouter, Routes, Route } from "react-router-dom"
-import { GA_MEASUREMENT_ID } from "./lib/config"
-import { initGA } from "./lib/analytics"
+/** Application entry point with routing */
+import React from "react";
+import ReactDom from "react-dom/client";
+import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { GA_MEASUREMENT_ID } from "./lib/config";
+import { initGA } from "./lib/analytics";
 
-import Privacy from "./pages/Privacy"
-import RootRedirect from "./pages/RootRedirect"
-import Terms from "./pages/Terms"
-import VariantA from "./pages/VariantA"
-import VariantB from "./pages/VariantB"
+import Privacy from "./pages/Privacy";
+import RootRedirect from "./pages/RootRedirect";
+import Terms from "./pages/Terms";
+import VariantA from "./pages/VariantA";
+import VariantB from "./pages/VariantB";
 
-import "./index.css"
+import "./index.css";
 
-initGA(GA_MEASUREMENT_ID)
+/** Initialize Google Analytics */
+initGA(GA_MEASUREMENT_ID);
 
 // function Terms() {
 //   return (

--- a/src/pages/Privacy.tsx
+++ b/src/pages/Privacy.tsx
@@ -1,3 +1,4 @@
+/** Privacy policy page */
 export default function Privacy() {
   return (
     <main className="max-w-3xl mx-auto px-4 py-12">

--- a/src/pages/RootRedirect.tsx
+++ b/src/pages/RootRedirect.tsx
@@ -4,15 +4,16 @@ import { useNavigate } from "react-router-dom";
 
 const VAR_KEY = "chavexls_variant";
 
+/** Redirect root path to variant A or B */
 export default function RootRedirect(): React.ReactElement | null {
     const navigate = useNavigate()
     useEffect(() => {
         // tenta ler variante já atribuida
         let variant: string | null = null;
-        try { variant = localStorage.getItem(VAR_KEY) } catch {}
+        try { variant = localStorage.getItem(VAR_KEY); } catch { /* ignore */ }
         if (!variant) {
             variant = Math.random() < 0.5 ? "A" : "B";
-            try { localStorage.setItem(VAR_KEY, variant) } catch {} 
+            try { localStorage.setItem(VAR_KEY, variant); } catch { /* ignore */ }
         }
         navigate(variant === "A" ? "/a" : "/b", { replace: true })
     }, [navigate]);

--- a/src/pages/Terms.tsx
+++ b/src/pages/Terms.tsx
@@ -1,3 +1,4 @@
+/** Beta program terms page */
 export default function Terms() {
     return (
         <main className="max-w-3xl mx-auto px-4 py-12">

--- a/src/pages/VariantA.tsx
+++ b/src/pages/VariantA.tsx
@@ -12,6 +12,7 @@ import Pricing from '../components/Pricing';
 import SecurityLGPD from '../components/SecurityLGPD';
 import XlsxPreview from '../components/XlsxPreview';
 
+/** Marketing landing page variant A */
 export default function VariantA() {
     const [selectedPlan, setSelectedPlan] = useState<'starter' | 'business' | ''>('');
 
@@ -66,7 +67,7 @@ export default function VariantA() {
           'Suporte técnico',
         ],
         badge: 'Mais Popular',
-        highlightTone: "emerald" as "emerald", // gives the “ring”/bluish edge of the highlight
+        highlightTone: "emerald" as const, // gives the “ring”/bluish edge of the highlight
       },
     ];
 

--- a/src/pages/VariantB.tsx
+++ b/src/pages/VariantB.tsx
@@ -13,6 +13,7 @@ import Pricing from "../components/Pricing";
 import SecurityLGPD from "../components/SecurityLGPD";
 import XlsxPreview from "../components/XlsxPreview";
 
+/** Marketing landing page variant B */
 export default function VariantB() {
     const [selectedPlan, setSelectedPlan] = useState<"starter" | "business" | "">("");
 
@@ -26,8 +27,9 @@ export default function VariantB() {
         if (el) el.scrollIntoView({ behavior: "smooth", block: "start" });
     }
 
-    function handleTryDemoClick() {
-        trackEvent('try_demo_click', { variant: 'B' });
+    // Send dedicated event for demo generation CTA and reveal playground
+    function handleDemoGenerateClick() {
+        trackEvent('demo_generate_click', { variant: 'B' });
         scrollTo('demo');
     }
 
@@ -80,7 +82,7 @@ export default function VariantB() {
                   title="Planilha fiscal confiável a partir do seu XML"
                   subtitle={<>Tipagem correta. Totais por NCM/CFOP. LGPD: 'apagar agora' + expiração em 48h. <strong>Teste a amostra agora.</strong></>}
                   primary={{ label: 'Entrar no Beta', onClick: handleBetaClick }}
-                  secondary={{ label: 'Gerar XLSX de exemplo', onClick: handleTryDemoClick }}
+                  secondary={{ label: 'Gerar XLSX de exemplo', onClick: handleDemoGenerateClick }}
                   helperText="Convites do Beta enviados por e-mail."
                   chips={[
                     { label: 'Sem cartão de crédito no Beta.', tone: 'emerald' },


### PR DESCRIPTION
## Summary
- add dedicated `demo_generate_click` event for sample CTA
- fix mismatched form start event names and lead submission typo
- add documentation across components and helpers

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb5bbfbf90832aad8ba371a654e00d